### PR TITLE
Bump webpackbar to v7

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,5 +27,8 @@
     "dependencies": {
         "handsontable": "^15.2.0",
         "xlsx": "^0.18.5"
+    },
+    "overrides": {
+        "webpackbar": "^7.0.0"
     }
 }


### PR DESCRIPTION
### Changes:
Webpack 5.106.0 added stricter, which breaks webpackbar v5 (used by Laravel Mix), so we override it to use v7.