### PR TITLE
Migrate dc backup to deployment

### DIFF
--- a/openshift/Makefile
+++ b/openshift/Makefile
@@ -148,7 +148,7 @@ db-backup-deploy-postgresql:
 	test -n "$(NAMESPACE)"
 	test -n "$(BUILD_NAMESPACE)"
 	test -n "$(BACKUP_POSTGRESQL_APP_NAME)"
-	@echo "+\n++ Creating deploy config resoures for database backups on $(NAMESPACE)\n+"
+	@echo "+\n++ Creating deployment resources for database backups on $(NAMESPACE)\n+"
 	oc -n $(NAMESPACE) process -f backup-deploy.yaml \
   	-p BACKUP_POSTGRESQL_APP_NAME=$(BACKUP_POSTGRESQL_APP_NAME) \
   	-p IMAGE_NAMESPACE=$(BUILD_NAMESPACE) \
@@ -167,3 +167,5 @@ db-backup-deploy-postgresql:
 		-p DATABASE_SECRET_PASSWORD_KEY_NAME=superuser-password \
   	-p ENVIRONMENT_FRIENDLY_NAME='$(NAMESPACE) POSTGRESQL DB Backups' \
 		| oc -n $(NAMESPACE) apply -f -
+	@oc -n $(NAMESPACE) rollout restart deployment/$(BACKUP_POSTGRESQL_APP_NAME)
+	$(call rollout_and_wait,deployment/$(BACKUP_POSTGRESQL_APP_NAME))

--- a/openshift/backup-deploy.yaml
+++ b/openshift/backup-deploy.yaml
@@ -94,8 +94,8 @@ objects:
       ftp-password: ${FTP_PASSWORD}
       ftp-url-host: ${FTP_URL_HOST}
 
-  - kind: DeploymentConfig
-    apiVersion: v1
+  - kind: Deployment
+    apiVersion: apps/v1
     metadata:
       name: ${BACKUP_POSTGRESQL_APP_NAME}
       labels:
@@ -107,20 +107,10 @@ objects:
     spec:
       strategy:
         type: Recreate
-      triggers:
-        - type: ConfigChange
-        - type: ImageChange
-          imageChangeParams:
-            automatic: true
-            containerNames:
-              - ${BACKUP_POSTGRESQL_APP_NAME}
-            from:
-              kind: ImageStreamTag
-              namespace: ${IMAGE_NAMESPACE}
-              name: ${SOURCE_IMAGE_NAME}:${TAG_NAME}
       replicas: 1
       selector:
-        name: ${BACKUP_POSTGRESQL_APP_NAME}
+        matchLabels:
+          name: ${BACKUP_POSTGRESQL_APP_NAME}
       template:
         metadata:
           name: ${BACKUP_POSTGRESQL_APP_NAME}
@@ -145,7 +135,9 @@ objects:
                     path: ${CONFIG_FILE_NAME}
           containers:
             - name: ${BACKUP_POSTGRESQL_APP_NAME}
-              image: ""
+              image: >-
+                image-registry.openshift-image-registry.svc:5000/${IMAGE_NAMESPACE}/${SOURCE_IMAGE_NAME}:${TAG_NAME}
+              imagePullPolicy: Always
               ports: []
               env:
                 - name: BACKUP_STRATEGY


### PR DESCRIPTION
#### Changes:

- Updated the configuration in `backup-deploy.yaml` to use the Deployment label
- Removed the DC ImageChange trigger and replaced it with `rollout restart` during deployment